### PR TITLE
Refactor AdminViewQueue to use service layer instead of repositories

### DIFF
--- a/src/TriQue.App/Data/Repositories/AdminRepository.cs
+++ b/src/TriQue.App/Data/Repositories/AdminRepository.cs
@@ -55,48 +55,25 @@ namespace TriQue.Data.Repositories
                 : AdminLevel.Staff; 
         }
 
-        public void UpdateDriverStatus(int driverID, int statusID)
+        public DataTable GetAllAdmins()
         {
             string query = @"
-                UPDATE Driver SET StatusID = @statusID
-                WHERE DriverID = @driverID
-            ";
+                SELECT 
+                    u.FirstName || ' ' || u.LastName AS [Admin Name],
+                    al.LevelName AS [Authorization Level],
+                    u.PhoneNumber AS [Contact Number]
+                FROM Admin a
+                JOIN User u ON a.UserID = u.UserID
+                JOIN AdminLevel al ON a.LevelID = al.LevelID
+                ORDER BY a.LevelID ASC";
 
-            _dbHelper.ExecuteNonQuery(query,
-                new SqliteParameter("@statusID", statusID),
-                new SqliteParameter("@driverID", driverID)
-            );
-        }
+            using var conn = _dbHelper.GetConnection();
+            conn.Open();
 
-        public void ResetQueue(int routeID)
-        {
-
-            string updateStatus = @"
-                UPDATE Driver 
-                SET StatusID = 3
-                WHERE StatusID = 1
-                AND DriverID IN (
-                    SELECT qe.DriverID 
-                    FROM QueueEntry qe
-                    JOIN Queue q ON qe.QueueID = q.QueueID
-                    WHERE q.RouteID = @routeID
-                )
-                ";
-
-            _dbHelper.ExecuteNonQuery(updateStatus,
-                new SqliteParameter("@routeID", routeID)
-            );
-
-            string clearQueue = @"
-                DELETE FROM QueueEntry
-                WHERE QueueID = (
-                    SELECT QueueID FROM Queue WHERE RouteID = @routeID
-                )
-                ";
-
-            _dbHelper.ExecuteNonQuery(clearQueue,
-                new SqliteParameter("@routeID", routeID)
-            );
+            using var cmd = new SqliteCommand(query, conn);
+            DataTable dt = new DataTable();
+            dt.Load(cmd.ExecuteReader());
+            return dt;
         }
 
         public (string FullName, string PhoneNumber, string LevelName)? GetAdminSettings(int userID)
@@ -124,75 +101,6 @@ namespace TriQue.Data.Repositories
                 PhoneNumber: reader["PhoneNumber"].ToString() ?? "",
                 LevelName: reader["LevelName"].ToString() ?? ""
             );
-        }
-
-        public DataTable GetAllAdmins()
-        {
-            string query = @"
-                SELECT 
-                    u.FirstName || ' ' || u.LastName AS [Admin Name],
-                    al.LevelName AS [Authorization Level],
-                    u.PhoneNumber AS [Contact Number]
-                FROM Admin a
-                JOIN User u ON a.UserID = u.UserID
-                JOIN AdminLevel al ON a.LevelID = al.LevelID
-                ORDER BY a.LevelID ASC";
-
-            using var conn = _dbHelper.GetConnection();
-            conn.Open();
-
-            using var cmd = new SqliteCommand(query, conn);
-            DataTable dt = new DataTable();
-            dt.Load(cmd.ExecuteReader());
-            return dt;
-        }
-
-        public DataTable GetQueueByGroupID(int groupID, int routeID)
-        {
-            string query = @"
-                SELECT 
-                    CASE 
-                        WHEN qe.Position IS NOT NULL THEN CAST(qe.Position AS TEXT)
-                        ELSE '-'
-                    END AS Ranking,
-                    d.BodyNumber,
-                    u.FirstName || ' ' || u.LastName AS DriverName,
-                    ds.StatusName AS TripStatus,
-                    d.DriverID
-                FROM Driver d
-                JOIN User u ON d.UserID = u.UserID
-                JOIN DriverStatus ds ON d.StatusID = ds.StatusID
-                LEFT JOIN Queue q ON q.RouteID = @routeID
-                LEFT JOIN QueueEntry qe ON qe.QueueID = q.QueueID 
-                    AND qe.DriverID = d.DriverID
-                WHERE d.GroupID = @groupID
-                ORDER BY 
-                    CASE WHEN qe.Position IS NULL THEN 1 ELSE 0 END,
-                    qe.Position";
-
-            using var reader = _dbHelper.ExecuteReader(query,
-                new SqliteParameter("@groupID", groupID),
-                new SqliteParameter("@routeID", routeID));
-
-            var table = new DataTable();
-            table.Columns.Add("Ranking", typeof(string));
-            table.Columns.Add("BodyNumber", typeof(string));
-            table.Columns.Add("DriverName", typeof(string));
-            table.Columns.Add("TripStatus", typeof(string));
-            table.Columns.Add("DriverID", typeof(int));
-
-            while (reader.Read())
-            {
-                table.Rows.Add(
-                    reader.GetString(0),
-                    reader.GetString(1),
-                    reader.GetString(2),
-                    reader.GetString(3),
-                    reader.GetInt32(4)
-                );
-            }
-
-            return table;
         }
     }
 }

--- a/src/TriQue.App/Data/Repositories/QueueRepository.cs
+++ b/src/TriQue.App/Data/Repositories/QueueRepository.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Data;
 using TriQue.Helpers;
+using TriQue.Models;
 
 namespace TriQue.Data.Repositories
 {
@@ -14,24 +15,34 @@ namespace TriQue.Data.Repositories
             _dbHelper = new DatabaseHelper();
         }
 
-        public int GetQueueIdByRouteId(int routeId)
+        #region Queue Retrieval
+
+        public Queue? GetQueueByRouteId(int routeId)
         {
             string query = @"
-                SELECT QueueID 
+                SELECT QueueID, RouteID
                 FROM Queue 
                 WHERE RouteID = $routeId
                 LIMIT 1;
             ";
 
-            var result = _dbHelper.ExecuteScalar(
-                query,
-                new Microsoft.Data.Sqlite.SqliteParameter("$routeId", routeId)
-            );
+            using var conn = _dbHelper.GetConnection();
+            conn.Open();
 
-            if (result == null)
-                throw new Exception("Queue not found for this route.");
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = query;
+            cmd.Parameters.AddWithValue("$routeId", routeId);
 
-            return Convert.ToInt32(result);
+            using var reader = cmd.ExecuteReader();
+
+            if (!reader.Read())
+                return null;
+
+            return new Queue
+            {
+                QueueID = reader.GetInt32(0),
+                RouteID = reader.GetInt32(1)
+            };
         }
 
         // status, route, and rank
@@ -72,20 +83,146 @@ namespace TriQue.Data.Repositories
             return dt.Rows.Count > 0 ? dt.Rows[0] : null;
         }
 
-        public void AddQueueEntry(int queueId, int driverId, int position)
+        // driver view queue status datagrid
+        public DataTable GetQueueDrivers(int queueId)
+        {
+            string query = @"
+                SELECT 
+                    ROW_NUMBER() OVER (ORDER BY qe.Position ASC) AS Position,
+                    u.FirstName || ' ' || u.LastName AS DriverName,
+                    d.BodyNumber AS BodyNumber,
+                    ds.StatusName AS Status
+                FROM QueueEntry qe
+                INNER JOIN Driver d ON qe.DriverID = d.DriverID
+                INNER JOIN User u ON d.UserID = u.UserID
+                INNER JOIN DriverStatus ds ON d.StatusID = ds.StatusID
+                WHERE qe.QueueID = $queueId
+                AND d.StatusID != 3
+                ORDER BY qe.Position ASC;
+            ";
+
+            using var conn = _dbHelper.GetConnection();
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = query;
+            cmd.Parameters.AddWithValue("$queueId", queueId);
+
+            DataTable dt = new DataTable();
+            dt.Load(cmd.ExecuteReader());
+            return dt;
+        }
+
+        public DataTable GetQueueByGroupID(int groupID, int routeID)
+        {
+            string query = @"
+                SELECT 
+                    CASE 
+                        WHEN qe.Position IS NOT NULL THEN CAST(qe.Position AS TEXT)
+                        ELSE '-'
+                    END AS Ranking,
+                    d.BodyNumber,
+                    u.FirstName || ' ' || u.LastName AS DriverName,
+                    ds.StatusName AS TripStatus,
+                    d.DriverID
+                FROM Driver d
+                JOIN User u ON d.UserID = u.UserID
+                JOIN DriverStatus ds ON d.StatusID = ds.StatusID
+                LEFT JOIN Queue q ON q.RouteID = @routeID
+                LEFT JOIN QueueEntry qe ON qe.QueueID = q.QueueID 
+                    AND qe.DriverID = d.DriverID
+                WHERE d.GroupID = @groupID
+                ORDER BY 
+                    CASE WHEN qe.Position IS NULL THEN 1 ELSE 0 END,
+                    qe.Position";
+
+            using var reader = _dbHelper.ExecuteReader(query,
+                new SqliteParameter("@groupID", groupID),
+                new SqliteParameter("@routeID", routeID));
+
+            var table = new DataTable();
+            table.Columns.Add("Ranking", typeof(string));
+            table.Columns.Add("BodyNumber", typeof(string));
+            table.Columns.Add("DriverName", typeof(string));
+            table.Columns.Add("TripStatus", typeof(string));
+            table.Columns.Add("DriverID", typeof(int));
+
+            while (reader.Read())
+            {
+                table.Rows.Add(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.GetInt32(4)
+                );
+            }
+
+            return table;
+        }
+
+        #endregion
+
+        #region Queue Actions
+
+        public void AddQueueEntry(QueueEntry entry)
         {
             string query = @"
                 INSERT INTO QueueEntry (QueueID, DriverID, Position, JoinedAt)
-                VALUES ($queueId, $driverId, $position, datetime('now'));
+                VALUES ($queueId, $driverId, $position, $joinedAt);
             ";
 
             _dbHelper.ExecuteNonQuery(
                 query,
-                new Microsoft.Data.Sqlite.SqliteParameter("$queueId", queueId),
-                new Microsoft.Data.Sqlite.SqliteParameter("$driverId", driverId),
-                new Microsoft.Data.Sqlite.SqliteParameter("$position", position)
+                new SqliteParameter("$queueId", entry.QueueID),
+                new SqliteParameter("$driverId", entry.DriverID),
+                new SqliteParameter("$position", entry.QueuePosition),
+                new SqliteParameter("$joinedAt", entry.JoinedAt)
             );
         }
+
+        public void RemoveDriverFromQueue(int driverID, int queueID)
+        {
+            string query = @"
+                DELETE FROM QueueEntry
+                WHERE DriverID = $driverID AND QueueID = $queueID;
+            ";
+            _dbHelper.ExecuteNonQuery(query,
+                new SqliteParameter("$driverID", driverID),
+                new SqliteParameter("$queueID", queueID));
+        }
+
+        public void ResetQueue(int routeID)
+        {
+
+            string updateStatus = @"
+                UPDATE Driver 
+                SET StatusID = 3
+                WHERE StatusID = 1
+                AND DriverID IN (
+                    SELECT qe.DriverID 
+                    FROM QueueEntry qe
+                    JOIN Queue q ON qe.QueueID = q.QueueID
+                    WHERE q.RouteID = @routeID
+                )
+                ";
+
+            _dbHelper.ExecuteNonQuery(updateStatus,
+                new SqliteParameter("@routeID", routeID)
+            );
+
+            string clearQueue = @"
+                DELETE FROM QueueEntry
+                WHERE QueueID = (
+                    SELECT QueueID FROM Queue WHERE RouteID = @routeID
+                )
+                ";
+
+            _dbHelper.ExecuteNonQuery(clearQueue,
+                new SqliteParameter("@routeID", routeID)
+            );
+        }
+
+        #endregion
 
         public int GetNextPosition(int queueId)
         {
@@ -97,7 +234,7 @@ namespace TriQue.Data.Repositories
 
             var result = _dbHelper.ExecuteScalar(
                 query,
-                new Microsoft.Data.Sqlite.SqliteParameter("$queueId", queueId)
+                new SqliteParameter("$queueId", queueId)
             );
 
             return Convert.ToInt32(result);
@@ -113,8 +250,8 @@ namespace TriQue.Data.Repositories
 
             var result = _dbHelper.ExecuteScalar(
                 query,
-                new Microsoft.Data.Sqlite.SqliteParameter("$queueId", queueId),
-                new Microsoft.Data.Sqlite.SqliteParameter("$driverId", driverId)
+                new SqliteParameter("$queueId", queueId),
+                new SqliteParameter("$driverId", driverId)
             );
 
             return Convert.ToInt32(result) > 0;
@@ -144,44 +281,6 @@ namespace TriQue.Data.Repositories
                 new SqliteParameter("$queueId", queueId));
         }
 
-        public void RemoveDriverFromQueue(int driverID, int queueID)
-        {
-            string query = @"
-                DELETE FROM QueueEntry
-                WHERE DriverID = $driverID AND QueueID = $queueID;
-            ";
-            _dbHelper.ExecuteNonQuery(query,
-                new SqliteParameter("$driverID", driverID),
-                new SqliteParameter("$queueID", queueID));
-        }
-
-        // driver view queue status datagrid
-        public DataTable GetQueueDrivers(int queueId)
-        {
-            string query = @"
-                SELECT 
-                    ROW_NUMBER() OVER (ORDER BY qe.Position ASC) AS Position,
-                    u.FirstName || ' ' || u.LastName AS DriverName,
-                    d.BodyNumber AS BodyNumber,
-                    ds.StatusName AS Status
-                FROM QueueEntry qe
-                INNER JOIN Driver d ON qe.DriverID = d.DriverID
-                INNER JOIN User u ON d.UserID = u.UserID
-                INNER JOIN DriverStatus ds ON d.StatusID = ds.StatusID
-                WHERE qe.QueueID = $queueId
-                AND d.StatusID != 3
-                ORDER BY qe.Position ASC;
-            ";
-
-            using var conn = _dbHelper.GetConnection();
-            conn.Open();
-            using var cmd = conn.CreateCommand();
-            cmd.CommandText = query;
-            cmd.Parameters.AddWithValue("$queueId", queueId);
-
-            DataTable dt = new DataTable();
-            dt.Load(cmd.ExecuteReader());
-            return dt;
-        }
+ 
     }
 }

--- a/src/TriQue.App/Forms/AdminViewQueue.cs
+++ b/src/TriQue.App/Forms/AdminViewQueue.cs
@@ -1,5 +1,4 @@
 using TriQue.Data.Repositories;
-using TriQue.Forms;
 using TriQue.Helpers.Animation;
 using TriQue.Services;
 

--- a/src/TriQue.App/Forms/AdminViewQueue.cs
+++ b/src/TriQue.App/Forms/AdminViewQueue.cs
@@ -8,7 +8,7 @@ namespace TriQue.Forms
     public partial class AdminViewQueue : Form
     {
         private readonly RotationService _rotationService;
-        private readonly DriverRepository _driverRepo;
+
         private readonly int _userID;
 
         public AdminViewQueue(int userID)
@@ -16,10 +16,12 @@ namespace TriQue.Forms
             InitializeComponent();
 
             _rotationService = new RotationService();
-            _driverRepo = new DriverRepository();
             _userID = userID;
         }
 
+        #region Route Buttons
+
+        // Provincial Capitol button
         private async void btnRouteA_Click(object sender, EventArgs e)
         {
             int? groupID = _rotationService.GetGroupIDForRouteToday(101);
@@ -30,6 +32,7 @@ namespace TriQue.Forms
             await ModalAnimator.ShowModalAsync(this, new QueueModal("Provincial Capitol", 101, _userID, groupID.Value));
         }
 
+        // Grand Terminal button
         private async void btnRouteB_Click(object sender, EventArgs e)
         {
             int? groupID = _rotationService.GetGroupIDForRouteToday(102);
@@ -41,6 +44,7 @@ namespace TriQue.Forms
             await ModalAnimator.ShowModalAsync(this, new QueueModal("Grand Terminal", 102, _userID, groupID.Value));
         }
 
+        // SM Batangas button
         private async void btnRouteC_Click(object sender, EventArgs e)
         {
             int? groupID = _rotationService.GetGroupIDForRouteToday(103);
@@ -52,6 +56,7 @@ namespace TriQue.Forms
             await ModalAnimator.ShowModalAsync(this, new QueueModal("SM Batangas", 103, _userID, groupID.Value));
         }
 
+        // Waltermart button
         private async void btnRouteD_Click(object sender, EventArgs e)
         {
             int? groupID = _rotationService.GetGroupIDForRouteToday(104);
@@ -62,6 +67,7 @@ namespace TriQue.Forms
             await ModalAnimator.ShowModalAsync(this, new QueueModal("WalterMart", 104, _userID, groupID.Value));
         }
 
+        // Brgy. Tulo button
         private async void btnRouteE_Click(object sender, EventArgs e)
         {
             int? groupID = _rotationService.GetGroupIDForRouteToday(105);
@@ -73,6 +79,7 @@ namespace TriQue.Forms
             await ModalAnimator.ShowModalAsync(this, new QueueModal("Brgy. Tulo", 105, _userID, groupID.Value));
         }
 
+        // BSU Alangilan button
         private async void btnRouteF_Click(object sender, EventArgs e)
         {
             int? groupID = _rotationService.GetGroupIDForRouteToday(106);
@@ -84,7 +91,10 @@ namespace TriQue.Forms
             await ModalAnimator.ShowModalAsync(this, new QueueModal("BSU Alangilan", 106, _userID, groupID.Value));
         }
 
-        // navbar
+        #endregion
+
+        #region navigation
+
         private async void DashBtn_Click(object sender, EventArgs e)
         {
             await FormAnimator.SwitchAsync(this, new AdminForm(_userID));
@@ -134,10 +144,17 @@ namespace TriQue.Forms
 
         private async void LogoutBtn_Click(object sender, EventArgs e)
         {
-            var authService = new AuthenticationService();
-            authService.Logout(_userID);
+            if (MessageBox.Show("Are you sure you want to logout?",
+                "Confirm Logout",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question) != DialogResult.Yes)
+                return;
+
+            new AuthenticationService().Logout(_userID);
 
             await FormAnimator.SwitchAsync(this, new LoginForm());
         }
+
+        #endregion
     }
 }

--- a/src/TriQue.App/Forms/DriverViewQueue.cs
+++ b/src/TriQue.App/Forms/DriverViewQueue.cs
@@ -24,7 +24,7 @@ namespace TriQue.Forms
             _routeID = routeID;
             _userID = userID;
             _driverID = _driverService.GetDriverId(userID) ?? 0;
-            _queueID = _queueService.GetQueueIdByRouteId(routeID);
+            _queueID = _queueService.GetQueueIdByRouteId(routeID) ?? 0;
 
             LoadView();
         }

--- a/src/TriQue.App/Forms/QueueModal.cs
+++ b/src/TriQue.App/Forms/QueueModal.cs
@@ -8,40 +8,43 @@ namespace TriQue.Forms
 {
     public partial class QueueModal : Form
     {
-        private readonly AdminRepository _adminRepo = new();
-        private readonly TripRepository _tripRepo = new();
-        private TripService _tripService;
-        private readonly string _routeName;
+        private readonly TripService _tripService = new();
+        private readonly AdminService _adminService = new();
+        private readonly QueueService _queueService = new();
+        private readonly DriverService _driverService = new();
+
         private readonly int _routeID;
         private readonly int _userID;
         private readonly int _groupID;
+
         private DataTable _fullTable;
         private bool _isSuperAdmin;
 
         public QueueModal(string routeName, int routeID, int userID, int groupID)
         {
             InitializeComponent();
-            _tripService = new TripService();
 
-            _routeName = routeName;
             _routeID = routeID;
             _userID = userID;
             _groupID = groupID;
 
-            // modal title
             this.Text = routeName;
             this.StartPosition = FormStartPosition.CenterScreen;
 
+            LoadQueueModal();
+        }
+
+        private void LoadQueueModal()
+        {
             CheckAdminLevel();
             SetupGrid();
             LoadQueue();
             SetupSearch();
-
         }
 
         private void CheckAdminLevel()
         {
-            var level = _adminRepo.GetAdminLevel(_userID);
+            var level = _adminService.GetAdminLevel(_userID);
             _isSuperAdmin = level == AdminLevel.SuperAdmin;
 
             if (!_isSuperAdmin)
@@ -114,41 +117,9 @@ namespace TriQue.Forms
             DriverListDataGrid.Columns.AddRange(chk, colRank, colBody, colName, colStatus, colAction);
         }
 
-        private void DgvQueue_CellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
-        {
-            var colName = DriverListDataGrid.Columns[e.ColumnIndex].Name;
-
-            // hide ranking for Finished drivers
-            if (colName == "colRanking")
-            {
-                var row = DriverListDataGrid.Rows[e.RowIndex];
-                var status = row.Cells["colStatus"].Value?.ToString();
-                if (status == "Finished")
-                    e.Value = "-";
-                return;
-            }
-
-            if (colName != "colStatus") return;
-
-            e.CellStyle.Font = new Font("Segoe UI", 9f, FontStyle.Bold);
-            var value = e.Value?.ToString();
-
-            Color statusColor = value switch
-            {
-                "Waiting" => Color.Orange,
-                "OnTrip" => Color.FromArgb(0, 150, 0),
-                "Finished" => Color.FromArgb(0, 86, 179),
-                _ => Color.FromArgb(91, 91, 91)
-            };
-
-            e.CellStyle.ForeColor = statusColor;
-            e.CellStyle.SelectionForeColor = statusColor;
-            e.CellStyle.SelectionBackColor = Color.FromArgb(231, 229, 255);
-        }
-
         private void LoadQueue()
         {
-            _fullTable = _adminRepo.GetQueueByGroupID(_groupID, _routeID);
+            _fullTable = _queueService.GetQueueByGroupID(_groupID, _routeID);
             DriverListDataGrid.DataSource = _fullTable;
 
             foreach (DataGridViewRow row in DriverListDataGrid.Rows)
@@ -194,6 +165,40 @@ namespace TriQue.Forms
             };
         }
 
+        private void DgvQueue_CellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
+        {
+            var colName = DriverListDataGrid.Columns[e.ColumnIndex].Name;
+
+            // hide ranking for Finished drivers
+            if (colName == "colRanking")
+            {
+                var row = DriverListDataGrid.Rows[e.RowIndex];
+                var status = row.Cells["colStatus"].Value?.ToString();
+                if (status == "Finished")
+                    e.Value = "-";
+                return;
+            }
+
+            if (colName != "colStatus") return;
+
+            e.CellStyle.Font = new Font("Segoe UI", 9f, FontStyle.Bold);
+            var value = e.Value?.ToString();
+
+            Color statusColor = value switch
+            {
+                "Waiting" => Color.Orange,
+                "OnTrip" => Color.FromArgb(0, 150, 0),
+                "Finished" => Color.FromArgb(0, 86, 179),
+                _ => Color.FromArgb(91, 91, 91)
+            };
+
+            e.CellStyle.ForeColor = statusColor;
+            e.CellStyle.SelectionForeColor = statusColor;
+            e.CellStyle.SelectionBackColor = Color.FromArgb(231, 229, 255);
+        }
+
+        #region Queue actions
+
         private void UpdateStatusBtn_Click_1(object sender, EventArgs e)
         {
             int updated = 0;
@@ -206,25 +211,20 @@ namespace TriQue.Forms
                 var action = row.Cells["colAction"].Value?.ToString();
                 int driverID = Convert.ToInt32(_fullTable.Rows[row.Index]["DriverID"]);
 
-                int statusID;
-
                 switch (action)
                 {
                     case "OnTrip":
-                        statusID = 2;
                         _tripService.StartTrip(driverID, _routeID);
-                        _adminRepo.UpdateDriverStatus(driverID, 2);
+                        _driverService.UpdateStatus(driverID, DriverStatus.OnTrip);
                         break;
 
                     case "Finished":
-                        statusID = 3;
                         _tripService.EndTrip(driverID, _routeID);
-                        _adminRepo.UpdateDriverStatus(driverID, statusID);
+                        _driverService.UpdateStatus(driverID, DriverStatus.Finished);
                         break;
 
                     default:
-                        statusID = 1;
-                        _adminRepo.UpdateDriverStatus(driverID, statusID);
+                        _driverService.UpdateStatus(driverID, DriverStatus.Waiting);
                         break;
                 }
 
@@ -264,13 +264,15 @@ namespace TriQue.Forms
 
             if (confirm != DialogResult.Yes) return;
 
-            _adminRepo.ResetQueue(_routeID);
+            _queueService.ResetQueue(_routeID);
             MessageBox.Show("Queue has been reset.!",
                 "Success",
                 MessageBoxButtons.OK,
                 MessageBoxIcon.Information);
             LoadQueue();
         }
+
+        #endregion
 
     }
 }

--- a/src/TriQue.App/Models/Queue.cs
+++ b/src/TriQue.App/Models/Queue.cs
@@ -8,16 +8,5 @@ namespace TriQue.Models
     {
         public int QueueID { get; set; }
         public int RouteID { get; set; }
-        public int CurrentSize { get; set; } = 0;
-
-        public void AddToQueue()
-        {
-            CurrentSize++;
-        }
-
-        public void RemoveToQueue()
-        {
-            if (CurrentSize > 0) CurrentSize--;
-        }
     }
 }

--- a/src/TriQue.App/Services/DriverService.cs
+++ b/src/TriQue.App/Services/DriverService.cs
@@ -49,7 +49,5 @@ namespace TriQue.Services
         {
             return _driverRepo.GetDriversPerRoute();
         }
-
-
     }
 }

--- a/src/TriQue.App/Services/QueueService.cs
+++ b/src/TriQue.App/Services/QueueService.cs
@@ -17,16 +17,26 @@ namespace TriQue.Services
             _driverRepo = new DriverRepository();
         }
 
-        public int GetQueueIdByRouteId(int routeID)
+        public int? GetQueueIdByRouteId(int routeID)
         {
-            return _queueRepo.GetQueueIdByRouteId(routeID);
+            return _queueRepo.GetQueueByRouteId(routeID)?.QueueID;
+        }
+
+        public DataTable GetQueueByGroupID(int groupID, int routeID)
+        {
+            return _queueRepo.GetQueueByGroupID(groupID, routeID);
         }
 
         public bool IsDriverInQueue(int driverID, int routeID)
         {
-            int queueID = _queueRepo.GetQueueIdByRouteId(routeID);
-            return _queueRepo.IsDriverAlreadyInQueue(queueID, driverID);
+            var queue = _queueRepo.GetQueueByRouteId(routeID);
+
+            if (queue == null)
+                return false;
+
+            return _queueRepo.IsDriverAlreadyInQueue(queue.QueueID, driverID);
         }
+
 
         public DataRow? GetQueueDriver(int queueID, int driverID)
         {
@@ -48,16 +58,33 @@ namespace TriQue.Services
             _queueRepo.ReorderQueuePositions(queueID);
         }
 
+        public void ResetQueue(int routeID)
+        {
+            _queueRepo.ResetQueue(routeID);
+        }
+
         public string JoinQueue(int driverID, int routeID)
         {
-            int queueID = _queueRepo.GetQueueIdByRouteId(routeID);
+            var queue = _queueRepo.GetQueueByRouteId(routeID);
 
-            bool alreadyJoined = _queueRepo.IsDriverAlreadyInQueue(queueID, driverID);
+            if (queue == null)
+                return "Queue not found.";
+
+            bool alreadyJoined = _queueRepo.IsDriverAlreadyInQueue(queue.QueueID, driverID);
             if (alreadyJoined)
                 return "Already in queue.";
 
-            int position = _queueRepo.GetNextPosition(queueID);
-            _queueRepo.AddQueueEntry(queueID, driverID, position);
+            int position = _queueRepo.GetNextPosition(queue.QueueID);
+
+            var entry = new QueueEntry
+            {
+                QueueID = queue.QueueID,
+                DriverID = driverID,
+                QueuePosition = position,
+                JoinedAt = DateTime.Now
+            };
+
+            _queueRepo.AddQueueEntry(entry);
             _driverRepo.UpdateStatus(driverID, 1);
 
             return $"Joined queue. Position: #{position}";


### PR DESCRIPTION
**Description**

This refactor removes direct repository usage from `AdminViewQueue` and replaces it with service layer calls.

**Changes Included**

- Removed direct repository usage from `AdminViewQueue`
- Replaced repository calls with `RotationService`, `DriverService`, and `TripService`
- Moved data access logic to service layer
- Cleaned up form initialization and improved maintainability