### PR TITLE
chore(rotationservice-tests): clean and simplify comments

### DIFF
--- a/src/TriQue.Tests/Services/RotationServiceTests.cs
+++ b/src/TriQue.Tests/Services/RotationServiceTests.cs
@@ -18,39 +18,31 @@ namespace TriQue.Tests.Services
         public void Setup()
         {
             _dbHelper = new DatabaseHelper();
+
             var dbInitializer = new DatabaseInitializer(_dbHelper, AppConfig.Configuration);
             dbInitializer.Initialize();
+
             _routeRepo = new RouteRepository();
         }
-
-        // =============================================
-        // NULL / EMPTY CASES
-        // =============================================
 
         [TestMethod]
         public void GetTodayRoute_ShouldReturnNull_WhenGroupIsNotFound()
         {
-            // GroupID 0 and 999 do not exist in the database
+            // checks invalid group IDs
             var service = new RotationService();
 
             Assert.IsNull(service.GetTodayRoute(0));
             Assert.IsNull(service.GetTodayRoute(999));
         }
 
-        // =============================================
-        // GROUP A TESTS
-        // =============================================
-
         [TestMethod]
         public void GetTodayRoute_GroupA_OnMonday_ShouldReturnIndex0()
         {
-            // Group A has RotationDay = Monday (1), baseOffset = 0
-            // Monday dayOffset = 0
-            // routeIndex = (0 + 0) % 6 = 0 -> first route
+            // checks Group A Monday route
             var routes = _routeRepo.GetAllRoutes();
 
-            int baseOffset = (int)RotationDay.Monday - 1; // 0
-            int dayOffset = 0; // Monday
+            int baseOffset = (int)RotationDay.Monday - 1;
+            int dayOffset = 0;
             int expected = (baseOffset + dayOffset) % routes.Count;
 
             Assert.AreEqual(0, expected);
@@ -60,32 +52,24 @@ namespace TriQue.Tests.Services
         [TestMethod]
         public void GetTodayRoute_GroupA_OnSunday_ShouldUseDayOffset6()
         {
-            // Group A has RotationDay = Monday (1), baseOffset = 0
-            // Sunday dayOffset = 6
-            // routeIndex = (0 + 6) % 6 = 0 → wraps back to first route
+            // checks Group A Sunday route
             var routes = _routeRepo.GetAllRoutes();
 
-            int baseOffset = (int)RotationDay.Monday - 1; // 0
-            int dayOffset = 6; // Sunday
+            int baseOffset = (int)RotationDay.Monday - 1;
+            int dayOffset = 6;
             int expected = (baseOffset + dayOffset) % routes.Count;
 
             Assert.AreEqual(0, expected);
         }
 
-        // =============================================
-        // GROUP B TESTS
-        // =============================================
-
         [TestMethod]
         public void GetTodayRoute_GroupB_OnMonday_ShouldReturnIndex1()
         {
-            // Group B has RotationDay = Tuesday (2), baseOffset = 1
-            // Monday dayOffset = 0
-            // routeIndex = (1 + 0) % 6 = 1 -> second route
+            // checks Group B Monday route
             var routes = _routeRepo.GetAllRoutes();
 
-            int baseOffset = (int)RotationDay.Tuesday - 1; // 1
-            int dayOffset = 0; // Monday
+            int baseOffset = (int)RotationDay.Tuesday - 1;
+            int dayOffset = 0;
             int expected = (baseOffset + dayOffset) % routes.Count;
 
             Assert.AreEqual(1, expected);
@@ -95,32 +79,24 @@ namespace TriQue.Tests.Services
         [TestMethod]
         public void GetTodayRoute_GroupB_OnSunday_ShouldReturnIndex1()
         {
-            // Group B has RotationDay = Tuesday (2), baseOffset = 1
-            // Sunday dayOffset = 6
-            // routeIndex = (1 + 6) % 6 = 1 -> second route
+            // checks Group B Sunday route
             var routes = _routeRepo.GetAllRoutes();
 
-            int baseOffset = (int)RotationDay.Tuesday - 1; // 1
-            int dayOffset = 6; // Sunday
+            int baseOffset = (int)RotationDay.Tuesday - 1;
+            int dayOffset = 6;
             int expected = (baseOffset + dayOffset) % routes.Count;
 
             Assert.AreEqual(1, expected);
         }
 
-        // =============================================
-        // WRAP AROUND TEST
-        // =============================================
-
         [TestMethod]
         public void GetTodayRoute_ShouldWrapAround_WhenOffsetExceedsRouteCount()
         {
-            // Group F has RotationDay = Saturday (6), baseOffset = 5
-            // Saturday dayOffset = 5
-            // routeIndex = (5 + 5) % 6 = 4 -> wraps correctly
+            // checks route wrap around
             var routes = _routeRepo.GetAllRoutes();
 
-            int baseOffset = (int)RotationDay.Saturday - 1; // 5
-            int dayOffset = 5; // Saturday
+            int baseOffset = (int)RotationDay.Saturday - 1;
+            int dayOffset = 5;
             int expected = (baseOffset + dayOffset) % routes.Count;
 
             Assert.IsTrue(expected >= 0 && expected < routes.Count,
@@ -130,7 +106,7 @@ namespace TriQue.Tests.Services
         [TestMethod]
         public void GetTodayRoute_ShouldNeverReturnOutOfBoundsIndex()
         {
-            // Test all 6 groups across all 7 days — index must always be valid
+            // checks valid route indexes
             var routes = _routeRepo.GetAllRoutes();
             int routeCount = routes.Count;
 
@@ -140,7 +116,7 @@ namespace TriQue.Tests.Services
                 RotationDay.Thursday, RotationDay.Friday, RotationDay.Saturday
             };
 
-            int[] dayOffsets = { 0, 1, 2, 3, 4, 5, 6 }; // Mon to Sun
+            int[] dayOffsets = { 0, 1, 2, 3, 4, 5, 6 };
 
             foreach (var rotDay in rotationDays)
             {
@@ -156,17 +132,12 @@ namespace TriQue.Tests.Services
             }
         }
 
-        // =============================================
-        // ALL DAYS OF THE WEEK - GROUP A
-        // =============================================
-
         [TestMethod]
         public void GetTodayRoute_GroupA_AllDays_ShouldMapCorrectly()
         {
-            // Group A baseOffset = 0
-            // Day offsets: Mon=0, Tue=1, Wed=2, Thu=3, Fri=4, Sat=5, Sun=6
-            // Expected indices: 0, 1, 2, 3, 4, 5, 0
+            // checks weekly rotation mapping
             var routes = _routeRepo.GetAllRoutes();
+
             int baseOffset = 0;
             int[] dayOffsets = { 0, 1, 2, 3, 4, 5, 6 };
             int[] expectedIndices = { 0, 1, 2, 3, 4, 5, 0 };
@@ -174,40 +145,43 @@ namespace TriQue.Tests.Services
             for (int i = 0; i < dayOffsets.Length; i++)
             {
                 int actual = (baseOffset + dayOffsets[i]) % routes.Count;
+
                 Assert.AreEqual(expectedIndices[i], actual,
                     $"Group A on dayOffset={dayOffsets[i]}: expected index {expectedIndices[i]}, got {actual}");
             }
         }
 
-        // =============================================
-        // FULL ROTATION CORRECTNESS
-        // =============================================
-
         [TestMethod]
         public void GetTodayRoute_AllGroups_ShouldReturnValidRoute()
         {
-            // All 6 valid group IDs should return a non-null route
+            // checks all valid groups
             var service = new RotationService();
+
             int[] validGroupIDs = { 1, 2, 3, 4, 5, 6 };
 
             foreach (var groupID in validGroupIDs)
             {
                 var result = service.GetTodayRoute(groupID);
-                Assert.IsNotNull(result, $"GroupID {groupID} returned null but should return a route");
+
+                Assert.IsNotNull(result,
+                    $"GroupID {groupID} returned null but should return a route");
             }
         }
 
         [TestMethod]
         public void GetTodayRoute_ShouldReturnRouteWithValidID()
         {
-            // Route returned should have a valid RouteID (101-106)
+            // checks valid route IDs
             var service = new RotationService();
+
             int[] validRouteIDs = { 101, 102, 103, 104, 105, 106 };
 
             for (int groupID = 1; groupID <= 6; groupID++)
             {
                 var result = service.GetTodayRoute(groupID);
+
                 Assert.IsNotNull(result);
+
                 CollectionAssert.Contains(validRouteIDs, result.RouteID,
                     $"GroupID {groupID} returned unexpected RouteID {result?.RouteID}");
             }


### PR DESCRIPTION
Cleaned and simplified comments in RotationServiceTests for better readability and maintainability.

Changes made:
- Replaced long comments with concise descriptions
- Improved readability of test methods
- Removed unnecessary comment clutter
- Kept test behavior and logic unchanged